### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Skyfield Data
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## 1.0.0 (2020-05-05)
 
 ### Data updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 # Changelog for Skyfield Data
 
-## master (unreleased)
+## 1.0.0 (2020-05-05)
 
-* Added ``expiration_limit`` argument for ``get_skyfield_data_path`` function. Enables to shift the expiration date limit by "n" days.
-* USNO file serving host has changed. Pointing now at ``ftp://cddis.nasa.gov/products/iers/`` for ``deltat.*`` files.
+### Data updates
+
+**Data files were downloaded on 2020-05-05.**
+
 * Updated ``deltat.data`` data file.
 * Updated ``Leap_Second.dat`` data file.
-* All expiration data items are also up-to-date as of 2020-05-05.
+* All expiration data items are up-to-date as of 2020-05-05.
+
+### Library Runtime Enhancements
+
+* Added ``expiration_limit`` argument for ``get_skyfield_data_path`` function. Enables to shift the expiration date limit by "n" days.
+
+### Downloader enhancement
+
+* USNO file serving host has changed. Pointing now at ``ftp://cddis.nasa.gov/products/iers/`` for ``deltat.*`` files.
+
+### Minor changes
+
+* Changes in Python ``setup.cfg`` classifiers.
 
 ## 0.1.0 (2019-10-04)
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Several issues are raised by these data files:
 
 |      File       |    Date    |
 |:---------------:|:----------:|
-|   deltat.data   | 2020-06-01 |
-| Leap_Second.dat | 2020-07-28 |
+|   deltat.data   | 2021-02-01 |
+| Leap_Second.dat | 2021-01-27 |
 |  deltat.preds   | 2021-01-01 |
 |    de421.bsp    | 2053-10-08 |
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = skyfield-data
-version = 0.2.0.dev0
+version = 1.0.0
 author = Bruno Bord
 author-email = bruno@jehaisleprintemps.net
 home-page = https://github.com/brunobord/skyfield-data
@@ -12,14 +12,12 @@ license-file = COPYING
 platform = any
 keywords = astronomy science
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = skyfield-data
-version = 1.0.0
+version = 1.1.0.dev0
 author = Bruno Bord
 author-email = bruno@jehaisleprintemps.net
 home-page = https://github.com/brunobord/skyfield-data


### PR DESCRIPTION
**First major version**

skyfield-data is considered as stable.

## Changelog:

### Data updates

**Data files were downloaded on 2020-05-05.**

* Updated ``deltat.data`` data file.
* Updated ``Leap_Second.dat`` data file.
* All expiration data items are up-to-date as of 2020-05-05.

### Library Runtime Enhancements

* Added ``expiration_limit`` argument for ``get_skyfield_data_path`` function. Enables to shift the expiration date limit by "n" days.

### Downloader enhancement

* USNO file serving host has changed. Pointing now at ``ftp://cddis.nasa.gov/products/iers/`` for ``deltat.*`` files.

### Minor changes

* Changes in Python ``setup.cfg`` classifiers.
