### PR TITLE
Add Python 3.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,12 @@
-sudo: false
-dist: xenial
+dist: bionic
 language: python
-install:
-    - pip install tox
-
-script:
-    - tox -e $TOXENV
-
+cache: pip
+install: pip install tox tox-travis
+script: tox -v
+python:
+- 2.7
+- 3.5
+- 3.6
+- 3.7
 matrix:
   fast_finish: true
-  include:
-    # Python version is just for the look on travis.
-    - python: 2.7
-      env: TOXENV=py27
-
-    - python: 3.5
-      env: TOXENV=py35
-
-    - python: 3.6
-      env: TOXENV=py36
-
-    - python: 3.7
-      env: TOXENV=py37
-      sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ python:
 - 3.5
 - 3.6
 - 3.7
+- 3.8
 matrix:
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Revamped/Simplified Travis configuration.
 * Removed tox.ini reference to Python 3.3 builds.
 * Warn users that this project is not compatible with Python 2.6.
+* Add Python 3.8 compatibility (#1).
 
 ## 1.0.0 (2020-05-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Revamped/Simplified Travis configuration.
 * Removed tox.ini reference to Python 3.3 builds.
+* Warn users that this project is not compatible with Python 2.6.
 
 ## 1.0.0 (2020-05-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+* Revamped/Simplified Travis configuration.
 
 ## 1.0.0 (2020-05-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Revamped/Simplified Travis configuration.
+* Removed tox.ini reference to Python 3.3 builds.
 
 ## 1.0.0 (2020-05-05)
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In order to be able to run the `download.py` script, we recommend to run it **fr
 make install-dev
 ```
 
-*Note:* This project is, and should be compatible with Python 2.7 and Python 3.5+, to keep the same Python compatiblity that `skyfield` has.
+*Note:* This project is, and should be compatible with Python 2.7 and Python 3.5+ up to 3.8, to keep the same Python compatiblity that `skyfield` has.
 
 **WARNING!**: This project is not compatible with Python 2.6.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ In order to be able to run the `download.py` script, we recommend to run it **fr
 make install-dev
 ```
 
-*Note:* This project is, and should be compatible with Python 2.6/2.7 and Python 3.5+, to be kept the same Python compatiblity that `skyfield` has.
+*Note:* This project is, and should be compatible with Python 2.7 and Python 3.5+, to keep the same Python compatiblity that `skyfield` has.
+
+**WARNING!**: This project is not compatible with Python 2.6.
 
 
 ## Copyright

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [options]
 zip_safe = false

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,3 @@ commands =
     pytest -s {posargs}
 deps =
     .[tests]
-
-
-[testenv:py33]
-deps = .
-commands = pip freeze -l

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py27,py35,py36,py37,py38
 
 
 [testenv]


### PR DESCRIPTION
Also, revamped a couple of things:

* Revamped/Simplified Travis configuration.
* Removed tox.ini reference to Python 3.3 builds.
* Warn users that this project is not compatible with Python 2.6.

Closes #1
