### PR TITLE
Enable Python 2.6 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+
+jobs:
+  build-and-test:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: "Deadsnakes and Python2.6"
+          command: |
+            sudo add-apt-repository ppa:deadsnakes/ppa
+            sudo apt-get update
+            sudo apt-get install python2.6 python2.6-dev
+      - run:
+          name: "Create TOX virtualenv"
+          command: virtualenv TOX --python=`which python2.6`
+      - run:
+          command: ./TOX/bin/pip install tox
+          name: "Install tox in TOX venv"
+      - run:
+          command: ./TOX/bin/tox -c tox-py26.ini
+          name: "Test against Python2.6"
+
+workflows:
+  main:
+    jobs:
+      - build-and-test

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ dist/
 build/
 *.egg-info/
 __pycache__/
+*.pyc
+.cache/
 venv/
 .tox/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Revamped/Simplified Travis configuration.
 * Removed tox.ini reference to Python 3.3 builds.
-* Warn users that this project is not compatible with Python 2.6.
 * Add Python 3.8 compatibility (#1).
+* Added Python 2.6 compatibility + circle-ci job, documentation amended, code fixed to be compatible with Python 2.6 (#6).
 
 ## 1.0.0 (2020-05-05)
 

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ install-dev:
 
 test:
 	tox
+
+test-py26:
+	tox -c tox-py26.ini

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data files for Skyfield
 
-[![Build Status](https://travis-ci.org/brunobord/skyfield-data.svg?branch=master)](https://travis-ci.org/brunobord/skyfield-data)
+[![Build Status](https://travis-ci.org/brunobord/skyfield-data.svg?branch=master)](https://travis-ci.org/brunobord/skyfield-data) | [![CircleCI](https://circleci.com/gh/brunobord/skyfield-data.svg?style=svg)](https://circleci.com/gh/brunobord/skyfield-data)
 
 ## Rationale
 
@@ -87,6 +87,8 @@ In order to trigger this warning, you can use the ``expiration_limit`` argument,
 
 ## Developers
 
+We assume that you'll be using a Python3.6+ version for all regular operations.
+
 We're providing a ``Makefile`` with basic targets to play around with the toolkit. use ``make help`` to get more details.
 
 In order to be able to run the `download.py` script, we recommend to run it **from a virtualenv** where you'd have installed the "dev" dependencies, using:
@@ -95,10 +97,46 @@ In order to be able to run the `download.py` script, we recommend to run it **fr
 make install-dev
 ```
 
-*Note:* This project is, and should be compatible with Python 2.7 and Python 3.5+ up to 3.8, to keep the same Python compatiblity that `skyfield` has.
+### Python compatibility
 
-**WARNING!**: This project is not compatible with Python 2.6.
+*Important:* This project is, and should stay compatible with Python 2.6, 2.7 and Python 3.5+ up to 3.8, to keep the same Python compatibility that `skyfield` has.
 
+### Hacking
+
+Improving or fixing `skyfield-data` will require you to have at least a virtualenv with `tox` installed on it.
+
+We'll ask you to add tests along your patch, to make sure that no regression or bug would be introduced by your patch or further ones.
+
+To make a quick'n'dirty test, inside your "tox-ready" virtualenv, run:
+
+```sh
+make test
+```
+
+to launch the Python 2.7 and Python 3.5+ test jobs.
+
+If you want to test your branch against Python 2.6, you'll have to setup a Python 2.6-ready tox environment, by doing something similar to:
+
+```sh
+sudo apt install python2.6 python2.6-dev  # dev headers to compile numpy
+mkvirtualenv TOX26 --python=`which python2.6`  # You will activate this venv with `workon TOX26`
+pip install tox
+tox -c tox-py26.ini
+```
+
+**Known issues**: on Ubuntu, you may be unable to build numpy at this point, due to misplaced C header files in your system. I've had hard times on Ubuntu, but your mileage may vary.
+
+If you don't want to or can't install Python 2.6 requirements, you'll have to rely on the Online CI jobs by Circle-CI.
+
+
+### Online CI with Travis & Circle-CI
+
+The online CI is done by two services:
+
+* [Travis](https://travis-ci.org/brunobord/skyfield-data): to run Python 2.7, 3.5+ to 3.8 tests.
+* [Circle-CI](https://circleci.com/gh/brunobord/skyfield-data): dedicated to run the Python 2.6 tests.
+
+If either one of them is failing, your PR won't be merged.
 
 ## Copyright
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6

--- a/skyfield_data/expirations.py
+++ b/skyfield_data/expirations.py
@@ -7,6 +7,10 @@ from .expiration_data import EXPIRATIONS
 
 __DATA_PATH = abspath(join(dirname(__file__), "data"))
 
+# IMPORTANT NOTE: This module has to keep compatibility with Python 2.6
+# That's the reason why it doesn't use ``format()`` to format strings, but the
+# old ``%`` formatting.
+
 
 def get_all():
     return EXPIRATIONS
@@ -31,15 +35,15 @@ def check_expirations(expiration_limit=0):
         expiration_date = expirations.get(filename)
         if expiration_date:
             message = (
-                "The file {} has expired."
+                "The file %s has expired."
                 " Please upgrade your version of `skyfield-data` or expect"
-                " computation errors").format(filename)
+                " computation errors") % filename
             if expiration_limit:
                 expiration_date -= timedelta(days=expiration_limit)
                 message = (
-                    "The file {} would expire in less than {} days."
+                    "The file %s would expire in less than %d days."
                     " Please upgrade your version of `skyfield-data` or expect"
-                    " computation errors").format(filename, expiration_limit)
+                    " computation errors") % (filename, expiration_limit)
 
             if date.today() >= expiration_date:
                 warnings.warn(message, RuntimeWarning)

--- a/tests/test_expiration_date.py
+++ b/tests/test_expiration_date.py
@@ -79,9 +79,11 @@ def test_wrong_custom_expiration_limit_check_expirations():
 
 def test_current_expiration_date():
     # Filter all files that would expire in 45 days
-    expired = {
-        k: v for k, v in EXPIRATIONS.items()
-        if date.today() >= v - timedelta(days=45)
-    }
+    # NOTE: this could be done using a dict comprehension, but this code has
+    # to be kept Python 2.6-compatible.
+    today = date.today()
+    expired = EXPIRATIONS.items()
+    expired = filter(lambda x: today >= x[1] - timedelta(days=45), expired)
+    expired = list(expired)
     assert not expired, \
-        "{} files(s) are about to expire: {}".format(len(expired), expired)
+        "%d files(s) are about to expire: %s" % (len(expired), expired)

--- a/tox-py26.ini
+++ b/tox-py26.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py26
+
+
+[testenv]
+commands =
+    pytest -s {posargs}
+deps =
+    wheel==0.29.0
+    numpy==1.11.3
+    .[tests]


### PR DESCRIPTION
* Added a dedicated tox configuration file, and a Makefile target to run
tests,
* Added circle-ci job to test Python2.6,
* Added Documentation about how to keep Python 2.6 compatibility,
* Fixed non-Python 2.6 code, sadly.
* Added classifiers for Python 2.6 in setup.