### PR TITLE
Release: v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog for Skyfield Data
 
-## master (unreleased)
+## 4.0.0 (2022-02-17)
 
 * Switching from Travis/CircleCI for tests and CI to Github Actions (inspired by #24, thank you a lot, @Deuchnord).
 * Dropped support for Python 3.5.
 * Confirmed support for Python 3.10.
-* **NOTE**: Temporarily skipped Python 2.6 tests.
+* **NOTE**: Temporarily skipped Python 2.6 tests. Since version 3.0.0, the runtime code hasn't been modified, so this means that it should still be compatible, although... We can't prove it.
+
+### Data updates
+
+**Data files were downloaded on 2022-12-15.**
+
 * Upgrade `finals2000A.all` file, which has expired, thanks @6ruff for the bug report (#20).
 
 ## 3.0.0 (2020-12-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Skyfield Data
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## 4.0.0 (2022-02-17)
 
 * Switching from Travis/CircleCI for tests and CI to Github Actions (inspired by #24, thank you a lot, @Deuchnord).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data files for Skyfield
 
-[![Build Status](https://travis-ci.org/brunobord/skyfield-data.svg?branch=master)](https://travis-ci.org/brunobord/skyfield-data) | [![CircleCI](https://circleci.com/gh/brunobord/skyfield-data.svg?style=svg)](https://circleci.com/gh/brunobord/skyfield-data)
+[![Tests](https://github.com/brunobord/skyfield-data/actions/workflows/tests.yml/badge.svg)](https://github.com/brunobord/skyfield-data/actions/workflows/tests.yml)
 
 ## Rationale
 
@@ -128,17 +128,13 @@ tox -c tox-py26.ini
 
 **Known issues**: on Ubuntu, you may be unable to build numpy at this point, due to misplaced C header files in your system. I've had hard times on Ubuntu, but your mileage may vary.
 
-If you don't want to or can't install Python 2.6 requirements, you'll have to rely on the Online CI jobs by Circle-CI.
-
+Note: At the moment, we can't prove that skyfield-data is 100% compatible with Python 2.6, because of a defunct CI. Although, we're pretty confident it is. Fingers crossed!
 
 ### Online CI with Travis & Circle-CI
 
-The online CI is done by two services:
+The online CI relies on Github Actions:
 
-* [Travis](https://travis-ci.org/brunobord/skyfield-data): to run Python 2.7, 3.5+ to 3.9 tests.
-* [Circle-CI](https://circleci.com/gh/brunobord/skyfield-data): dedicated to run the Python 2.6 tests.
-
-If either one of them is failing, your PR won't be merged.
+[![Tests](https://github.com/brunobord/skyfield-data/actions/workflows/tests.yml/badge.svg)](https://github.com/brunobord/skyfield-data/actions/workflows/tests.yml)
 
 ## Copyright
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = skyfield-data
-version = 4.0.0
+version = 4.1.0.dev0
 author = Bruno Bord
 author-email = bruno@jehaisleprintemps.net
 home-page = https://github.com/brunobord/skyfield-data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = skyfield-data
-version = 3.1.0.dev0
+version = 4.0.0
 author = Bruno Bord
 author-email = bruno@jehaisleprintemps.net
 home-page = https://github.com/brunobord/skyfield-data
@@ -19,16 +19,16 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 zip_safe = false
 include_package_data = True
-python_requires = >=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4
+python_requires = >=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4
 packages = skyfield_data
 setup_requires =
     setuptools


### PR DESCRIPTION
## Changes

* Switching from Travis/CircleCI for tests and CI to Github Actions (inspired by #24, thank you a lot, @Deuchnord).
* Dropped support for Python 3.5.
* Confirmed support for Python 3.10.
* **NOTE**: Temporarily skipped Python 2.6 tests. Since version 3.0.0, the runtime code hasn't been modified, so this means that it should still be compatible, although... We can't prove it.

### Data updates

**Data files were downloaded on 2022-12-15.**

* Upgrade `finals2000A.all` file, which has expired, thanks @6ruff for the bug report (#20).