### PR TITLE
v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Skyfield Data
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## 5.0.0 (2023-04-23)
 
 * Upgraded `finals2002A.all` file, which has expired. Thanks a lot to @ReimarBauer for the PR, and @thierry-FreeBSD for the bug report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Skyfield Data
 
-## master (unreleased)
+## 5.0.0 (2023-04-23)
 
 * Upgraded `finals2002A.all` file, which has expired. Thanks a lot to @ReimarBauer for the PR, and @thierry-FreeBSD for the bug report.
 * Dropped support for Python 3.6.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = skyfield-data
-version = 4.1.0.dev0
+version = 5.0.0
 author = Bruno Bord
 author-email = bruno@jehaisleprintemps.net
 home-page = https://github.com/brunobord/skyfield-data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = skyfield-data
-version = 5.0.0
+version = 5.1.0.dev0
 author = Bruno Bord
 author-email = bruno@jehaisleprintemps.net
 home-page = https://github.com/brunobord/skyfield-data


### PR DESCRIPTION
## File changes:

* Upgraded `finals2002A.all` file, which has expired. Thanks a lot to @ReimarBauer for the PR, and @thierry-FreeBSD for the bug report.

## Python compatibility changes:

* Dropped support for Python 3.6.
* Confirm support for Python 3.11.

